### PR TITLE
Adjust sign text alignment

### DIFF
--- a/Speedhelper.js
+++ b/Speedhelper.js
@@ -430,7 +430,7 @@ function renderSigns(activeConfig, holder, click) {
     // The speed value
     const speedValue = document.createElement("div");
     speedValue.id = 'spd_'+ allowedSpeed;
-    speedValue.style.cssText = 'text-align:center;margin-top:'+(dims[2] - (dims[2]*2*(1 - scale)))+'px;font-size:' + (10 * scale) + 'px;font-family:\'Varela Round\',sans-serif;color:#000; font-weight:bold;visibility:'+dims[3];
+    speedValue.style.cssText = 'text-align:center;line-height:'+(dims[1]*scale)+'px;font-size:' + (10 * scale) + 'px;font-family:\'Varela Round\',sans-serif;color:#000; font-weight:bold;visibility:'+dims[3];
     speedValue.innerHTML = allowedSpeed;
     sign.append(speedValue);
     holder.append(sign);

--- a/Speedhelper.js
+++ b/Speedhelper.js
@@ -448,7 +448,7 @@ function renderClearSign(activeConfig, holder) {
   // Get width/height of sign background img
   const scale = options.iconScale / 100;
   //sign.style.cssText = 'cursor:pointer;float:left;width:'+(34*scale)+'px;height:'+(34*scale)+'px;background-image: url(\''+ emptySign + '\');background-size:contain;';
-  sign.style.cssText = 'cursor:pointer;float:left;width:'+(dims[1]*scale)+'px;height:'+(dims[0]*scale)+'px;background-image: url(\''+ bgImage + '\');background-size:contain;';
+  sign.style.cssText = 'cursor:pointer;float:left;width:'+(dims[1]*scale)+'px;height:'+(dims[0]*scale)+'px;';
 
   sign.onclick = () => clickSegmentSpeed(0);
 


### PR DESCRIPTION
- Changed styling to use `line-height` to center speed rather than `margin-top`. Still takes into account scaling %
- Removed background image from clear speed button

## Before

![image](https://github.com/user-attachments/assets/0ca7dee0-a600-4cdc-90ec-f8c58460b9e2)

## After

![image](https://github.com/user-attachments/assets/36cef7d6-6346-4456-b3e9-b9fc5e669507)

